### PR TITLE
setting of item creation and adding testing account to seed

### DIFF
--- a/app/models/elixir.rb
+++ b/app/models/elixir.rb
@@ -1,2 +1,0 @@
-class Elixir < Item
-end

--- a/app/models/equipment.rb
+++ b/app/models/equipment.rb
@@ -1,2 +1,0 @@
-class Equipment < Item
-end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,2 +1,18 @@
 class Item < ApplicationRecord
+  serialize :properties, Hash
+
+  def self.new_item(arguments)
+    item = Item.new
+    if (item.consumable = arguments[:consumable])
+      item.properties = { "stat" => arguments[:stat], "amount" => arguments[:amount] }
+    else
+      item.properties = { "slot" => arguments[:slot], "type" => arguments[:type],
+          "dmg" => arguments[:dmg], "armor" => arguments[:armor], "str" => arguments[:str],
+          "dex" => arguments[:dex], "vit" => arguments[:vit],
+          "int" => arguments[:int], "wis" => arguments[:wis] }
+    end
+    item.save
+  end
+
+  validates :consumable, presence: true
 end

--- a/db/migrate/20220802130737_create_items.rb
+++ b/db/migrate/20220802130737_create_items.rb
@@ -2,7 +2,7 @@ class CreateItems < ActiveRecord::Migration[6.1]
   def change
     create_table :items do |t|
       t.boolean :consumable, null: false
-      t.integer :item
+      t.string :properties
 
       t.timestamps
     end

--- a/db/migrate/20220802130910_create_equipment.rb
+++ b/db/migrate/20220802130910_create_equipment.rb
@@ -1,8 +1,0 @@
-class CreateEquipment < ActiveRecord::Migration[6.1]
-  def change
-    create_table :equipment do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/db/migrate/20220802131005_create_elixirs.rb
+++ b/db/migrate/20220802131005_create_elixirs.rb
@@ -1,8 +1,0 @@
-class CreateElixirs < ActiveRecord::Migration[6.1]
-  def change
-    create_table :elixirs do |t|
-
-      t.timestamps
-    end
-  end
-end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -46,11 +46,6 @@ ActiveRecord::Schema.define(version: 2022_08_02_141932) do
     t.index ["perso_id"], name: "index_current_stats_on_perso_id"
   end
 
-  create_table "elixirs", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "enemies", force: :cascade do |t|
     t.string "type", null: false
     t.string "name", null: false
@@ -95,15 +90,10 @@ ActiveRecord::Schema.define(version: 2022_08_02_141932) do
     t.index ["enemy_id"], name: "index_enemy_stats_on_enemy_id"
   end
 
-  create_table "equipment", force: :cascade do |t|
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-  end
-
   create_table "games", force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "perso_id", null: false
-    t.time "session_start", default: "2000-01-01 14:48:34", null: false
+    t.time "session_start", default: "2000-01-01 14:16:41", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["perso_id"], name: "index_games_on_perso_id"
@@ -147,7 +137,7 @@ ActiveRecord::Schema.define(version: 2022_08_02_141932) do
 
   create_table "items", force: :cascade do |t|
     t.boolean "consumable", null: false
-    t.integer "item"
+    t.string "properties"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -5,3 +5,9 @@
 #
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
+
+user = User.new
+user.email = "test@test.com"
+user.username = "tester"
+user.password = "testtest"
+user.save!

--- a/test/models/elixir_test.rb
+++ b/test/models/elixir_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class ElixirTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/models/equipment_test.rb
+++ b/test/models/equipment_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class EquipmentTest < ActiveSupport::TestCase
-  # test "the truth" do
-  #   assert true
-  # end
-end


### PR DESCRIPTION
gestion de la création d'item :
- la séparation des deux type d'item se fait par un hash dans Item
    -> suppression des migrations et des models d'elixir et d'equipment
    -> création de la méthode de class new_item pour gérer l'implémentation des paires key-values

ajout du compte de test dans la seed